### PR TITLE
Add karoo-ride-replay (ride simulator for Karoo extension developers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A community-driven list of known extensions and resources for the Karoo cycling 
   - [karoo-ksafe](#karoo-ksafe)
   - [karoo-gearbeeper](#karoo-gearbeeper)
   - [WaterMelonControl](#watermeloncontrol)
+  - [karoo-ride-replay](#karoo-ride-replay)
 - [Libraries](#libraries)
   - [ktor-client-karoo](#ktor-client-karoo)
 - [Resources](#resources)
@@ -446,6 +447,16 @@ To update extensions after you have installed them, long-tap the app icon on the
     - PLAYING widget shows the current track and artist and opens the active media app
     - MEDIA widget provides play/pause, next, and previous controls
     - VOLUME widget adjusts device music volume from a Karoo data page
+
+### karoo-ride-replay
+- **Extension Name:** [karoo-ride-replay](https://github.com/lgangitano/karoo-ride-replay)
+  - Description: Ride simulator for Karoo extension developers — replays a recorded FIT file as mock GPS plus virtual sensor data, so other extensions run as if a real ride were happening, without leaving home
+  - License: Open Source, Apache 2
+  - Features:
+    - Replays the rider's own recorded FIT files from the Karoo's `FitFiles/` folder
+    - Mock GPS injection via Android `LocationManager` — Karoo OS sees position move along the recorded route
+    - Virtual sensor devices for Power, Heart Rate, Cadence, Speed via the `karoo-ext` Device API
+    - Variable playback speed (1× / 2× / 5× / 10×) and start-time offset for fast iteration
 
 ## Libraries
 


### PR DESCRIPTION
Hi @timklge — thanks for keeping this list up to date.

Adding **karoo-ride-replay**, a ride-replay simulator I just open-sourced. It targets a specific gap I kept hitting while developing for Karoo: there's no way to exercise an extension end-to-end against real-feeling sensor + GPS input without an actual ride. So most of my iteration loops have been multi-hour transfers to a meaningful climb.

**What it does:**
- Reads any FIT file from the Karoo's `FitFiles/` folder (or a sideloaded one) and replays it at the recorded timing, with optional 1× / 2× / 5× / 10× speed-up and a start-time offset.
- Injects GPS via Android's `LocationManager` test-provider API — Karoo OS sees position move along the recorded route.
- Publishes four virtual sensors (Power / HR / Cadence / Speed) through the standard `karoo-ext` Device API, so consumer extensions pair to them exactly as they would to real BLE/ANT+ hardware.

**Repo / release / license:**
- Source: https://github.com/lgangitano/karoo-ride-replay
- Latest release: [v0.1.1-alpha](https://github.com/lgangitano/karoo-ride-replay/releases/latest) with a sideloadable APK and full Karoo 2 / Karoo 3 install instructions.
- Apache 2.0.

I cross-checked the existing list — `karoo-kpower` (which I credit as the virtual-sensor reference implementation) covers virtual power; this one extends the same pattern across four sensors plus mock GPS so it can drive any consumer extension that depends on a full live-ride feed.

Happy to adjust the entry's wording or position if you'd like it placed differently — I added it at the end of *Other extensions* to match the apparent chronological order.