### PR TITLE
Add Average Speed Colour extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A community-driven list of known extensions and resources for the Karoo cycling 
   - [karoo-wprimebalance](#karoo-wprimebalance)
   - [WPrimeKarooExtension](#WPrimeKarooExtension)
   - [karoo-colorspeed](#karoo-colorspeed)
+  - [Average Speed Colour](#average-speed-colour)
   - [CupRoute](#CupRoute)
   - [eiRadar](#eiRadar)
   - [7climb](#7climb)
@@ -309,6 +310,15 @@ To update extensions after you have installed them, long-tap the app icon on the
     - Current lap average vs. last lap average
     - Current speed vs. target speed
     - Lap speed vs. target speed
+
+### Average Speed Colour
+- **Extension Name:** [Average Speed Colour](https://github.com/j4m1eb/Karoo-Average-speed-colour)
+  - Description: An alternative colour-coded speed extension with configurable layout and display settings
+  - License: Open Source, Apache 2
+  - Features:
+    - Current speed vs. ride average, last lap average, or target speed
+    - Current lap average vs. last lap average or target speed
+    - Configurable target speed, colour palette, icons, and value positions
 
 ### CupRoute
 - **Extension Name:** [CupRoute](https://github.com/nairdam88/cuproute)


### PR DESCRIPTION
Adds Average Speed Colour as a separate Karoo extension with configurable colour-coded speed fields for ride average, lap average, and target speed.